### PR TITLE
Add invalid repo test2

### DIFF
--- a/Pulumi.github.prod.yaml
+++ b/Pulumi.github.prod.yaml
@@ -15,6 +15,14 @@ config:
         teams:
           - name: developers
             permission: push
+      - name: test2
+        # description: Test repository 2
+        topics:
+          - reactjs
+          - frontend
+        teams:
+          - name: developers
+            permission: push
     # Teams
     teams:
       - name: developers


### PR DESCRIPTION
This pr illustrates that the Pulumi preview job fails when the config has errors -> in this case there is a missing description for the repo.